### PR TITLE
Setting the permission

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -13,5 +13,9 @@ composer_global_packages: []
 
 composer_add_to_path: true
 
+
+composer_home_path_owner: "{{ default(omit) }}"
+composer_home_path_group: "{{ default(omit) }}"
+
 # GitHub OAuth token (used to help overcome API rate limits).
 composer_github_oauth_token: ''

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -26,12 +26,16 @@
 - name: Ensure composer directory exists.
   file:
     path: "{{ composer_home_path }}"
+    owner: "{{ composer_home_path_owner }}"
+    group: "{{ composer_home_path_group }}"
     state: directory
 
 - name: Add GitHub OAuth token for Composer (if configured).
   template:
     src: "auth.json.j2"
     dest: "{{ composer_home_path }}/auth.json"
+    owner: "{{ composer_home_path_owner }}"
+    group: "{{ composer_home_path_group }}"
   when: composer_github_oauth_token != ''
 
 - include: global-require.yml


### PR DESCRIPTION
Setting the permission over the composer folder and the file created for the github oauth-token. It is necessary for the cases where the role is execute with the root user.