### PR TITLE
Check if Composer is installed before downloading installer.

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,20 +1,26 @@
 ---
+- name: Check if Composer is installed.
+  stat: path={{ composer_path }}
+  register: composer_bin
+
 - name: Download Composer installer.
   get_url:
     url: https://getcomposer.org/installer
     dest: /tmp/composer-installer.php
     mode: 0755
+  when: not composer_bin.stat.exists
 
 - name: Run Composer installer.
   command: >
     php composer-installer.php
     chdir=/tmp
-    creates=/usr/local/bin/composer
+  when: not composer_bin.stat.exists
 
 - name: Move Composer into globally-accessible location.
   shell: >
     mv /tmp/composer.phar {{ composer_path }}
     creates={{ composer_path }}
+  when: not composer_bin.stat.exists
 
 - name: Update Composer to latest version (if configured).
   shell: >


### PR DESCRIPTION
If composer is already installed we don't need to download the installer again.

Also this PR only checks for the `composer_path` so if this changes it will still reinstall at new path.