### PR TITLE
Add setting to lock version of composer

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,10 @@ The path where composer will be installed and available to your system. Should b
 
 Set this to `true` to update Composer to the latest release every time the playbook is run.
 
+    composer_keep_version: ""
+
+Set this to `VERSION` to reset Composer to a specific release every time the playbook is run. Use when Composer has introduced a regression in its latest release.
+
     composer_home_path: '~/.composer'
     composer_home_owner: root
     composer_home_group: root

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,7 @@
 ---
 composer_path: /usr/local/bin/composer
 composer_keep_updated: false
+composer_keep_version: ''
 
 # The directory where global packages will be installed.
 composer_home_path: '~/.composer'

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -34,6 +34,13 @@
   changed_when: "'Updating to version' in composer_update.stdout"
   when: composer_keep_updated
 
+- name: Reset Composer to fixed version (if configured).
+  shell: >
+    {{ php_executable }} {{ composer_path }} self-update {{composer_keep_version}}
+  register: composer_update
+  changed_when: "'Updating to version' in composer_update.stdout"
+  when: composer_keep_version != ''
+
 - name: Ensure composer directory exists.
   file:
     path: "{{ composer_home_path }}"


### PR DESCRIPTION
We recently ran into https://github.com/composer/composer/issues/4818 which suddenly made it impossible to build our project. We worked around the issue by running a self-update with a previous version, but we now needed to write that into the provisioning for the project.