### PR TITLE
Add project vendor/bin to PATH.

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,14 @@ A list of packages to install globally (using `composer global require`). If you
 
 If `true`, and if there are any configured `composer_global_packages`, the `vendor/bin` directory inside `composer_home_path` will be added to the system's default `$PATH` (for all users).
 
+    composer_project_path: /path/to/project
+
+Path to a composer project.
+
+    composer_add_project_to_path: false
+
+If `true`, and if you have configured a `composer_project_path`, the `vendor/bin` directory inside `composer_project_path` will be added to the system's default `$PATH` (for all users).
+
     composer_github_oauth_token: ''
 
 GitHub OAuth token, used to avoid GitHub API rate limiting errors when building and rebuilding applications using Composer. Follow GitHub's directions to [Create a personal access token](https://help.github.com/articles/creating-an-access-token-for-command-line-use/) if you run into these rate limit errors.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -16,5 +16,9 @@ composer_global_packages: []
 
 composer_add_to_path: true
 
+# Add a project vendor/bin directory to the PATH
+composer_add_project_to_path: false
+#composer_project_path: /path/to/project/vendor/bin
+
 # GitHub OAuth token (used to help overcome API rate limits).
 composer_github_oauth_token: ''

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -51,3 +51,6 @@
 
 - include: global-require.yml
   when: composer_global_packages|length > 0
+
+- include: project-bin.yml
+  when: composer_add_project_to_path

--- a/tasks/project-bin.yml
+++ b/tasks/project-bin.yml
@@ -1,0 +1,6 @@
+---
+- name: Add composer_project_path bin directory to global $PATH.
+  template:
+    src: composer-project.sh.j2
+    dest: /etc/profile.d/composer-project.sh
+    mode: 0644

--- a/templates/composer-project.sh.j2
+++ b/templates/composer-project.sh.j2
@@ -1,0 +1,1 @@
+export PATH={{ composer_project_path }}/vendor/bin:$PATH


### PR DESCRIPTION
Add the ability to automatically add a projects `vendor/bin` directory to the PATH -- 

you wouldn't need the drush role if drush was a project dependency.
