### PR TITLE
fix for #29

### DIFF
--- a/tasks/global-require.yml
+++ b/tasks/global-require.yml
@@ -1,5 +1,7 @@
 ---
 - name: Install configured globally-required packages.
+  become: yes
+  become_user: "{{ composer_home_owner }}"
   environment:
     COMPOSER_HOME: "{{ composer_home_path }}"
   command: >

--- a/tasks/global-require.yml
+++ b/tasks/global-require.yml
@@ -1,9 +1,8 @@
 ---
 - name: Install configured globally-required packages.
-  become: yes
-  become_user: "{{ composer_home_owner }}"
-  shell: >
-    COMPOSER_HOME={{ composer_home_path }}
+  environment:
+    COMPOSER_HOME: "{{ composer_home_path }}"
+  command: >
     {{ composer_path }} global require {{ item.name }}:{{ item.release | default('@stable') }} --no-progress
     creates={{ composer_home_path }}/vendor/{{ item.name }}
   register: composer_global_require_result


### PR DESCRIPTION
AnsibleLintRule ANSIBLE0013 says:
Use shell only when shell functionality is required. So I changed an action from shell to command.

I also used a var {{ composer_path }} instead of the command name, because root has a restricted PATH without /usr/local/bin

AnsibleLintRule ANSIBLE0014 says:
Environment variables should be passed to shell or command through environment argument. I added that argument.
