### PR TITLE
Allow for easier non root user auth.json creation

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -42,6 +42,8 @@
     state: directory
 
 - name: Add GitHub OAuth token for Composer (if configured).
+  become: yes
+  become_user: "{{ composer_home_owner }}"
   template:
     src: "auth.json.j2"
     dest: "{{ composer_home_path }}/auth.json"


### PR DESCRIPTION
If you become the user defined as `composer_home_owner`, you don't have to change the happy default of`composer_home_path` from `~/.composer` to `/home/alternateuser/.composer` when generating a non root auth.json file.

Given what you said in issue #19, I still think auth.json generation is a viable configuration worth keeping in this role for now. However, it is definitely cool and welcome news that the rate limits have been removed for a vanilla composer without parallel installs.
