### PR TITLE
Use path specified in composer_project_path.

### DIFF
--- a/templates/composer-project.sh.j2
+++ b/templates/composer-project.sh.j2
@@ -1,1 +1,1 @@
-export PATH={{ composer_project_path }}/vendor/bin:$PATH
+export PATH={{ composer_project_path }}:$PATH


### PR DESCRIPTION
The value displayed in defaults/main.yml for composer_project_path indicates the correct location would contain the bin directory.  However the template is appending "vendor/bin".

Removing the "vendor/bin" from the template will allow the composer.json to use the "bin-dir" setting.

This feature seems to be working great, thanks.