### PR TITLE
Make role ansible 2.4 compatible

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ services: docker
 
 env:
   - distro: centos7
-  - distro: fedora24
+  - distro: fedora27
   - distro: ubuntu1604
   - distro: debian8
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -51,8 +51,8 @@
     group: "{{ composer_home_group }}"
   when: composer_github_oauth_token != ''
 
-- include: global-require.yml
+- import_tasks: global-require.yml
   when: composer_global_packages|length > 0
 
-- include: project-bin.yml
+- import_tasks: project-bin.yml
   when: composer_add_project_to_path


### PR DESCRIPTION
Fixes
```
[DEPRECATION WARNING]: The use of 'include' for tasks has been deprecated. Use 'import_tasks' for static inclusions or 'include_tasks'
for dynamic inclusions. This feature will be removed in a future release.
```