### PR TITLE
Add option to enforce downloads over SSL

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -22,3 +22,6 @@ composer_add_project_to_path: false
 
 # GitHub OAuth token (used to help overcome API rate limits).
 composer_github_oauth_token: ''
+
+# Force composer to use SSL connections.
+composer_enforce_ssl: false

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -51,6 +51,16 @@
     group: "{{ composer_home_group }}"
   when: composer_github_oauth_token != ''
 
+- name: Configure composer to only use ssl (if configured).
+  become: yes
+  become_user: "{{ composer_home_owner }}"
+  template:
+    src: "config.json"
+    dest: "{{ composer_home_path }}/config.json"
+    owner: "{{ composer_home_owner }}"
+    group: "{{ composer_home_group }}"
+  when: composer_enforce_ssl == true
+
 - include: global-require.yml
   when: composer_global_packages|length > 0
 

--- a/templates/config.json
+++ b/templates/config.json
@@ -1,0 +1,13 @@
+{
+  "config": {
+    "github-protocols": [
+      "https,ssh"
+    ]
+  },
+  "repositories": {
+    "packagist": {
+      "type": "composer",
+      "url": "https://packagist.org"
+    }
+  }
+}


### PR DESCRIPTION
When using composer behind a corporate firewall it is possible to run into Content-Length mismatch exceptions when said firewall performs deep packet inspection. I've run into this on several occasions and forcing composer to use SSL prevents this problem.

I've set the default to `false` to maintain full backwards compatibility, but would recommend enabling this to any user.