### PR TITLE
Fixed global require sometimes showing prompts

### DIFF
--- a/tasks/global-require.yml
+++ b/tasks/global-require.yml
@@ -1,7 +1,7 @@
 ---
 - name: Install configured globally-required packages.
   command: >
-    {{ composer_path }} global require {{ item.name }}:{{ item.release | default('@stable') }} --no-progress
+    {{ composer_path }} global require {{ item.name }}:{{ item.release | default('@stable') }} --no-progress --no-interaction
     creates={{ composer_home_path }}/vendor/{{ item.name }}
   environment:
     COMPOSER_HOME: "{{ composer_home_path }}"


### PR DESCRIPTION
If the user's token is invalid, Composer would prompt for a new token, stalling Ansible indefinitely. The `--no-interaction` switch prevents this.

Fixes #56.