### PR TITLE
CONDITIONAL_BARE_VARS deprecation fix in when condition

### DIFF
--- a/tasks/global-require.yml
+++ b/tasks/global-require.yml
@@ -15,4 +15,4 @@
     src: composer.sh.j2
     dest: /etc/profile.d/composer.sh
     mode: 0644
-  when: composer_add_to_path
+  when: composer_add_to_path | bool

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -40,7 +40,7 @@
     {{ php_executable }} {{ composer_path }} self-update
   register: composer_update
   changed_when: "'Updating to version' in composer_update.stdout"
-  when: composer_keep_updated
+  when: composer_keep_updated | bool
 
 - name: Ensure composer directory exists.
   file:
@@ -57,10 +57,10 @@
     dest: "{{ composer_home_path }}/auth.json"
     owner: "{{ composer_home_owner }}"
     group: "{{ composer_home_group }}"
-  when: composer_github_oauth_token
+  when: composer_github_oauth_token | bool
 
 - include_tasks: global-require.yml
   when: composer_global_packages|length > 0
 
 - include_tasks: project-bin.yml
-  when: composer_add_project_to_path
+  when: composer_add_project_to_path | bool


### PR DESCRIPTION
Ansible 2.12 deprecation warnings in when condition,

```
[DEPRECATION WARNING]: evaluating composer_keep_updated as a bare variable, this behaviour will go away and you might need to add |bool to the expression in the future. Also see CONDITIONAL_BARE_VARS 
configuration toggle.. This feature will be removed in version 2.12. Deprecation warnings can be disabled by setting deprecation_warnings=False in ansible.cfg.
[DEPRECATION WARNING]: evaluating composer_github_oauth_token as a bare variable, this behaviour will go away and you might need to add |bool to the expression in the future. Also see 
CONDITIONAL_BARE_VARS configuration toggle.. This feature will be removed in version 2.12. Deprecation warnings can be disabled by setting deprecation_warnings=False in ansible.cfg.
[DEPRECATION WARNING]: evaluating composer_add_project_to_path as a bare variable, this behaviour will go away and you might need to add |bool to the expression in the future. Also see 
CONDITIONAL_BARE_VARS configuration toggle.. This feature will be removed in version 2.12. Deprecation warnings can be disabled by setting deprecation_warnings=False in ansible.cfg.
```