### PR TITLE
oauth token bare var check

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -57,7 +57,7 @@
     dest: "{{ composer_home_path }}/auth.json"
     owner: "{{ composer_home_owner }}"
     group: "{{ composer_home_group }}"
-  when: composer_github_oauth_token | bool
+  when: composer_github_oauth_token|length > 0
 
 - include_tasks: global-require.yml
   when: composer_global_packages|length > 0


### PR DESCRIPTION
#59 erroneously treats `composer_github_oauth_token` as a bool resulting in the task to always be skipped.