### PR TITLE
Force composer_github_oauth_token to be string before checking its length

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -57,7 +57,7 @@
     dest: "{{ composer_home_path }}/auth.json"
     owner: "{{ composer_home_owner }}"
     group: "{{ composer_home_group }}"
-  when: composer_github_oauth_token | length > 0
+  when: composer_github_oauth_token | string | length > 0
 
 - include_tasks: global-require.yml
   when: composer_global_packages | length > 0


### PR DESCRIPTION
It seems useful to be able to store the `composer_github_oauth_token` in ansible-vault, but when i did that I ran into the following problem:

```
TASK [geerlingguy.composer : Add GitHub OAuth token for Composer (if configured).] ***
fatal: [host1]: FAILED! =>
  msg: |-
    The conditional check 'composer_github_oauth_token | length > 0' failed. The error was: Unexpected templating type error occurred on ({% if composer_github_oauth_token | length > 0 %} True {% else %} False {% endif %}): object of type 'AnsibleVaultEncryptedUnicode' has no len()

    The error appears to be in '/Users/-----/.ansible/roles/geerlingguy.composer/tasks/main.yml': line 52, column 3, but may
    be elsewhere in the file depending on the exact syntax problem.

    The offending line appears to be:


    - name: Add GitHub OAuth token for Composer (if configured).
      ^ here
```

Turns out encrypted strings are decrypted on the fly and do not have all the methods normal strings have. But we can work around this by ensuring the variable is a normal string before checking things like length: https://github.com/riemers/ansible-gitlab-runner/issues/67
