### PR TITLE
Fix creation of composer home directory with tilde

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -43,6 +43,8 @@
   when: composer_keep_updated | bool
 
 - name: Ensure composer directory exists.
+  become: true
+  become_user: "{{ composer_home_owner }}"
   file:
     path: "{{ composer_home_path }}"
     owner: "{{ composer_home_owner }}"


### PR DESCRIPTION
Reopening #65, which was closed by stalebot.

> If I set `composer_home_owner=someone` and `composer_home_group=someone`, but leave `composer_home_path` at its default value (`~/.composer`), the role would create `/home/root/.composer`, not the exepcted `/home/someone/.composer`.

> In turn this caused the next task ("Add GitHub OAuth token for Composer (if configured)") to fail because `/home/someone/.composer` did not exist.

> The PR should fixes this issue.