### PR TITLE
Install unzip.

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -4,6 +4,11 @@
     php_executable: php
   when: php_executable is not defined
 
+- name: Install prerequisite.
+  package:
+    name: unzip
+    state: present
+
 - name: Check if Composer is installed.
   stat: "path={{ composer_path }}"
   register: composer_bin


### PR DESCRIPTION
The installation of global packages fails if no `unzip` tool is present.

I am aware that this is quite rough around the edges, but I don't just want to open an issue complaining.

If this approach is valid, I will gladly implement something more scalable.