### PR TITLE
Fix: actually show the fail reason

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,8 +1,8 @@
 ---
 - name: Check if requested version parameters are valid
   fail:
-    message: You cannot request a specific version AND keeping composer up to date.
-      Set either composer_version or composer_keep_updated but not both.
+    msg: You cannot request a specific version AND keep the composer up to date.
+      Set either composer_version or composer_keep_updated, but not both.
   when: composer_version != '' and composer_keep_updated
 
 - name: Set php_executable variable to a default if not defined.


### PR DESCRIPTION
I am sorry. I admit that I didn't really test it before because I didn't expect you to merge it so fast, @geerlingguy... 😓 Now it's tested and working: 

```
TASK [geerlingguy.composer : Check if requested version parameters are valid] ******************************************************************************
fatal: [rocky8]: FAILED! => {
    "changed": false
}

MSG:

You cannot request a specific version AND keep the composer up to date. Set either composer_version or composer_keep_updated, but not both.

```