### PR TITLE
Support Check Mode

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -18,6 +18,7 @@
   uri:
     url: https://composer.github.io/installer.sig
     return_content: true
+  check_mode: false
   register: composer_installer_signature
   when: not composer_bin.stat.exists
 


### PR DESCRIPTION
The `uri` module does not support Check Mode. This means any playbook run in Check Mode will fail if Composer has not been installed previously.

The error looks like this:

> The task includes an option with an undefined variable. The error was: 'dict object' has no attribute 'content'. 'dict object' has no attribute 'content'

The object in question is `composer_installer_signature`. It is empty/undefined since the "Get Composer installer signature." task isn't executed in Check Mode.

By adding `check_mode: false` to the `uri` call, this will signal that it should run in check mode to satisfy the `composer_installer_signature` dependency for the "Download Composer installer." task.

https://docs.ansible.com/ansible/latest/collections/ansible/builtin/uri_module.html#attribute-check_mode