### PR TITLE
Allow {up,down}grade to specified `composer_version`

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -49,6 +49,13 @@
   changed_when: "'Updating to version' in composer_update.stdout"
   when: composer_keep_updated | bool
 
+- name: Update Composer to desired version (if configured).
+  command: >
+    {{ php_executable }} {{ composer_path }} self-update {{ composer_version }}
+  register: composer_update
+  changed_when: "'Upgrading to version' in composer_update.stdout or 'Updating to version' in composer_update.stdout"
+  when: composer_version != ''
+
 - name: Ensure composer directory exists.
   become: true
   become_user: "{{ composer_home_owner }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -46,7 +46,7 @@
   command: >
     {{ php_executable }} {{ composer_path }} self-update {{ composer_version_branch }}
   register: composer_update
-  changed_when: "'Updating to version' in composer_update.stdout"
+  changed_when: "'Upgrading to version' in composer_update.stdout or 'Updating to version' in composer_update.stdout"
   when: composer_keep_updated | bool
 
 - name: Update Composer to desired version (if configured).


### PR DESCRIPTION
I like having a reproducible environment everywhere, and as Composer is capable of up- and downgrading via `self-update`, I added a task to {up,down}grade to the version specified in the existing variable `composer_version`.

This way this variable is not only respected upon the initial installation, but also if Composer is already installed on a system.

I also updated the string to check for `changed_when`, since it is now 'Upgrading to version' instead of 'Updating to version'.

Cheers!